### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/virustotal.json
+++ b/virustotal.json
@@ -13,7 +13,7 @@
     "latest_tested_versions": [
         "Cloud, API v2 virustotal.com/vtapi/v2/, December 16 2021"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "publisher": "Splunk",
     "package_name": "phantom_virustotal",
     "fips_compliant": true,


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)